### PR TITLE
chore: bump wrangler compatibility_date

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,7 +5,7 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "linkflare",
-	"compatibility_date": "2025-09-02",
+	"compatibility_date": "2026-01-12",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],


### PR DESCRIPTION
Hey @jillesme 👋

This PR updates the `compatibility_date` in `wrangler.jsonc` to `2026-01-12`.

Keeping this value current ensures access to the latest Workers runtime features and bug fixes.

See: https://developers.cloudflare.com/workers/configuration/compatibility-dates/